### PR TITLE
Hotfix for LootTable

### DIFF
--- a/UnitedItems/pom.xml
+++ b/UnitedItems/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.unitedlands</groupId>
             <artifactId>UnitedSkills</artifactId>
-            <version>3.5.2</version>
+            <version>3.5.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/UnitedSkills/pom.xml
+++ b/UnitedSkills/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unitedlands</groupId>
     <artifactId>UnitedSkills</artifactId>
-    <version>3.5.2</version>
+    <version>3.5.3</version>
     <packaging>jar</packaging>
 
     <name>UnitedSkills</name>

--- a/UnitedSkills/src/main/java/org/unitedlands/skills/LootTable.java
+++ b/UnitedSkills/src/main/java/org/unitedlands/skills/LootTable.java
@@ -109,13 +109,20 @@ public class LootTable {
 
         if (ia == null) {
             // Generate a default ItemStack
-            Material itemMaterial = Material.getMaterial(Objects.requireNonNull(itemSection.getString("material")));
+            
+            Material itemMaterial; 
+
+            // If there is a list of random materials, pick one of them. If not, assert that there is just one material present.
             if (!itemSection.getStringList("materials").isEmpty()) {
                 itemMaterial = getRandomMaterial(itemSection);
+            } else {
+                itemMaterial = Material.getMaterial(Objects.requireNonNull(itemSection.getString("material")));
             }
+
             if (itemMaterial == null) {
                 return null;
             }
+
             item = new ItemStack(itemMaterial);
             addName(itemSection, item);
             addLore(itemSection, item);


### PR DESCRIPTION
Fixed LootTable not generating random items with multiple materials (e.g. in Fisherman Treasure Hunter ability)