### PR TITLE
Small Hotfixes

### DIFF
--- a/UnitedItems/pom.xml
+++ b/UnitedItems/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.unitedlands</groupId>
             <artifactId>UnitedSkills</artifactId>
-            <version>3.6.1</version>
+            <version>3.6.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/UnitedSkills/pom.xml
+++ b/UnitedSkills/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unitedlands</groupId>
     <artifactId>UnitedSkills</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
     <packaging>jar</packaging>
 
     <name>UnitedSkills</name>

--- a/UnitedSkills/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
+++ b/UnitedSkills/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
@@ -133,16 +133,16 @@ public class MinerAbilities implements Listener {
             ActiveSkill frenzy = new ActiveSkill(player, SkillType.FRENZY, cooldowns, durations);
             event.setExpToDrop(event.getExpToDrop() * (frenzy.getLevel() + 2));
             return;
-        }
-
-        ActiveSkill blastMining = new ActiveSkill(player, SkillType.BLAST_MINING, cooldowns, durations);
-        if (blastMining.isActive()) {
-            if (Utils.takeItemFromMaterial(player, Material.TNT)) {
-                block.getLocation().createExplosion(player, getPyrotechnicsPower(), false, true);
-                damagePickaxe(mainHand, 10 + (blastMining.getLevel()) * 3);
-            } else {
-                player.sendActionBar(Component.text("You must have TNT to use Blast Mining!", NamedTextColor.RED));
-                player.playSound(player, Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, 1, 1);
+        } else {
+            ActiveSkill blastMining = new ActiveSkill(player, SkillType.BLAST_MINING, cooldowns, durations);
+            if (blastMining.isActive()) {
+                if (Utils.takeItemFromMaterial(player, Material.TNT)) {
+                    block.getLocation().createExplosion(player, getPyrotechnicsPower(), false, true);
+                    damagePickaxe(mainHand, 10 + (blastMining.getLevel()) * 3);
+                } else {
+                    player.sendActionBar(Component.text("You must have TNT to use Blast Mining!", NamedTextColor.RED));
+                    player.playSound(player, Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, 1, 1);
+                }
             }
         }
     }
@@ -204,7 +204,8 @@ public class MinerAbilities implements Listener {
         if (level == 0) {
             return 4.0F;
         }
-        return (float) (4 + (4 * (level * unitedSkills.getConfig().getDouble("pyrotechnic-modifier.blast-strength", 0.2))));
+        return (float) (4
+                + (4 * (level * unitedSkills.getConfig().getDouble("pyrotechnic-modifier.blast-strength", 0.2))));
     }
 
     private boolean isMiner() {

--- a/UnitedSkills/src/main/java/org/unitedlands/skills/abilities/MobNetAbilities.java
+++ b/UnitedSkills/src/main/java/org/unitedlands/skills/abilities/MobNetAbilities.java
@@ -60,6 +60,10 @@ public class MobNetAbilities implements Listener {
         if (!(event.getRightClicked() instanceof LivingEntity))
             return;
 
+        // Don't consider players for catching -_-
+        if (event.getRightClicked() instanceof Player)
+            return;
+
         player = event.getPlayer();
 
         // Check if player has Towny permissions to catch mobs in the provided location


### PR DESCRIPTION
- Hotfix for Blast Mining messages being displayed during Frenzy in rare instances
- Hotfix for "no-catch-permission" message being shown when right-clicking a player in non-trusted towns (i.e. stop trying to catch players in mob nets, stupid) 