### PR TITLE
Hotfix for BlastMiner accidentally activating with Frenzy

### DIFF
--- a/UnitedItems/pom.xml
+++ b/UnitedItems/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.unitedlands</groupId>
             <artifactId>UnitedSkills</artifactId>
-            <version>3.6.4</version>
+            <version>3.6.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/UnitedSkills/pom.xml
+++ b/UnitedSkills/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unitedlands</groupId>
     <artifactId>UnitedSkills</artifactId>
-    <version>3.6.4</version>
+    <version>3.6.5</version>
     <packaging>jar</packaging>
 
     <name>UnitedSkills</name>

--- a/UnitedSkills/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
+++ b/UnitedSkills/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
@@ -135,6 +135,8 @@ public class MinerAbilities implements Listener {
             return;
         } else {
             ActiveSkill blastMining = new ActiveSkill(player, SkillType.BLAST_MINING, cooldowns, durations);
+            if (blastMining.getLevel() == 0)
+                return;
             if (blastMining.isActive()) {
                 if (Utils.takeItemFromMaterial(player, Material.TNT)) {
                     block.getLocation().createExplosion(player, getPyrotechnicsPower(), false, true);


### PR DESCRIPTION
Added an additional necessary check for BlastMiner level, because blastMiner.isActive() may return true if the (performance-dependent) task scheduled to reset isFrenzyActive is excecuted before Frenzy duration is actually over, leading the system to think that Blast Miner is active instead.