### PR TITLE
Hostility & wood duping fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/UnitedItems/pom.xml
+++ b/UnitedItems/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.unitedlands</groupId>
             <artifactId>UnitedSkills</artifactId>
-            <version>3.6.5</version>
+            <version>3.6.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/UnitedProtection/pom.xml
+++ b/UnitedProtection/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unitedlands.protection</groupId>
     <artifactId>UnitedProtection</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
 
     <name>UnitedProtection</name>

--- a/UnitedProtection/src/main/java/org/unitedlands/protection/listeners/PlayerListener.java
+++ b/UnitedProtection/src/main/java/org/unitedlands/protection/listeners/PlayerListener.java
@@ -12,6 +12,7 @@ import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -27,7 +28,7 @@ public class PlayerListener implements Listener {
         this.unitedProtection = unitedProtection;
     }
 
-    @EventHandler
+    @EventHandler (priority = EventPriority.HIGHEST)
     public void onBlockBreak(BlockBreakEvent event) {
         this.player = event.getPlayer();
         Block block = event.getBlock();
@@ -38,7 +39,7 @@ public class PlayerListener implements Listener {
 
     }
 
-    @EventHandler
+    @EventHandler (priority = EventPriority.HIGHEST)
     public void onBlockPlace(BlockPlaceEvent event) {
         this.player = event.getPlayer();
         Block block = event.getBlock();

--- a/UnitedPvP/pom.xml
+++ b/UnitedPvP/pom.xml
@@ -63,6 +63,10 @@
             <url>https://jitpack.io</url>
         </repository>
         <repository>
+            <id>glaremasters repo</id>
+            <url>https://repo.glaremasters.me/repository/towny/</url>
+        </repository>
+        <repository>
             <id>papermc</id>
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
@@ -90,9 +94,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.TownyAdvanced</groupId>
-            <artifactId>Towny</artifactId>
-            <version>0.101.0.3</version>
+            <groupId>com.palmergames.bukkit.towny</groupId>
+            <artifactId>towny</artifactId>
+            <version>0.101.0.0</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Placeholder API Dependency -->
         <dependency>

--- a/UnitedPvP/pom.xml
+++ b/UnitedPvP/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.unitedlands</groupId>
@@ -59,16 +59,16 @@
 
     <repositories>
         <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+        <repository>
             <id>papermc</id>
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
         <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
-        </repository>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
         </repository>
         <!-- Placeholder API Repository -->
         <repository>
@@ -92,8 +92,7 @@
         <dependency>
             <groupId>com.github.TownyAdvanced</groupId>
             <artifactId>Towny</artifactId>
-            <version>0.97.3.0</version>
-            <scope>provided</scope>
+            <version>0.101.0.3</version>
         </dependency>
         <!-- Placeholder API Dependency -->
         <dependency>

--- a/UnitedPvP/src/main/java/org/unitedlands/pvp/hooks/Placeholders.java
+++ b/UnitedPvP/src/main/java/org/unitedlands/pvp/hooks/Placeholders.java
@@ -34,9 +34,6 @@ public class Placeholders extends PlaceholderExpansion {
             PvpPlayer pvpPlayer = new PvpPlayer((Player) player);
             if (params.equalsIgnoreCase("status")) {
                 int hostility = pvpPlayer.getHostility();
-                if (hostility <= Status.AGGRESSIVE.getStartingValue()) {
-                    return "";
-                }
                 return pvpPlayer.getIconHex(hostility) + pvpPlayer.getStatus().getIcon();
             } else if (params.equalsIgnoreCase("status-string")) {
                 return String.valueOf(pvpPlayer.getStatus());

--- a/UnitedPvP/src/main/java/org/unitedlands/pvp/listeners/TownyListener.java
+++ b/UnitedPvP/src/main/java/org/unitedlands/pvp/listeners/TownyListener.java
@@ -3,8 +3,8 @@ package org.unitedlands.pvp.listeners;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.TownyUniverse;
 import com.palmergames.bukkit.towny.event.NewDayEvent;
-import com.palmergames.bukkit.towny.event.PlayerEnterTownEvent;
 import com.palmergames.bukkit.towny.event.nation.toggle.NationToggleNeutralEvent;
+import com.palmergames.bukkit.towny.event.player.PlayerEntersIntoTownBorderEvent;
 import com.palmergames.bukkit.towny.event.town.toggle.TownToggleNeutralEvent;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
@@ -147,10 +147,10 @@ public class TownyListener implements Listener {
     }
 
     @EventHandler
-    public void onTownEnter(PlayerEnterTownEvent event) {
+    public void onTownEnter(PlayerEntersIntoTownBorderEvent event) {
         player = event.getPlayer();
         Resident outlaw = towny.getResident(player);
-        Town town = event.getEnteredtown();
+        Town town = event.getEnteredTown();
 
         if (town.hasOutlaw(outlaw)) {
             player.showTitle(getOutlawWarningTitle(town));

--- a/UnitedSkills/pom.xml
+++ b/UnitedSkills/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.unitedlands</groupId>
     <artifactId>UnitedSkills</artifactId>
-    <version>3.6.5</version>
+    <version>3.6.6</version>
     <packaging>jar</packaging>
 
     <name>UnitedSkills</name>
@@ -89,7 +89,11 @@
             <id>codemc-repo</id>
             <url>https://repo.codemc.io/repository/maven-public/</url>
             <layout>default</layout>
-          </repository>
+        </repository>
+        <repository>
+            <id>glaremasters repo</id>
+            <url>https://repo.glaremasters.me/repository/towny/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -106,9 +110,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.TownyAdvanced</groupId>
-            <artifactId>Towny</artifactId>
-            <version>0.97.3.0</version>
+            <groupId>com.palmergames.bukkit.towny</groupId>
+            <artifactId>towny</artifactId>
+            <version>0.101.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -157,6 +161,6 @@
             <artifactId>item-nbt-api-plugin</artifactId>
             <version>2.13.2</version>
             <scope>provided</scope>
-          </dependency>
+        </dependency>
     </dependencies>
 </project>

--- a/UnitedSkills/src/main/java/org/unitedlands/skills/abilities/WoodcutterAbilities.java
+++ b/UnitedSkills/src/main/java/org/unitedlands/skills/abilities/WoodcutterAbilities.java
@@ -19,6 +19,7 @@ import org.bukkit.Particle;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -107,9 +108,13 @@ public class WoodcutterAbilities implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler (priority = EventPriority.LOW)
     public void onPreciseCut(BlockBreakEvent event) {
         player = event.getPlayer();
+        if (event.isCancelled())
+        {
+            return;
+        }
         if (!isWoodCutter()) {
             return;
         }


### PR DESCRIPTION
- Fixed shield not being displayed for peaceful players in UnitedPVP
- Fixed duping bug with Precision Cut ability below Y level 45 in UnitedSkills
- Towny API reference updates and fixes to outdated event classes