### PR TITLE
Added permission checks to custom item use

### DIFF
--- a/UnitedItems/pom.xml
+++ b/UnitedItems/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.unitedlands</groupId>
     <artifactId>UnitedItems</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.0-SNAPSHOT-1</version>
     <packaging>jar</packaging>
 
     <name>UnitedItems</name>
@@ -76,6 +76,14 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>sk89q-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
+        <repository>
+            <id>glaremasters repo</id>
+            <url>https://repo.glaremasters.me/repository/towny/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -98,15 +106,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.TownyAdvanced</groupId>
-            <artifactId>Towny</artifactId>
-            <version>0.101.1.0</version>
+            <groupId>com.palmergames.bukkit.towny</groupId>
+            <artifactId>towny</artifactId>
+            <version>0.101.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
             <version>1.21.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.13</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/UnitedItems/src/main/java/org/unitedlands/items/tools/BarkbinderAxe.java
+++ b/UnitedItems/src/main/java/org/unitedlands/items/tools/BarkbinderAxe.java
@@ -10,11 +10,21 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+import org.unitedlands.skills.Utils;
+
+import com.palmergames.bukkit.towny.TownyAPI;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class BarkbinderAxe extends CustomTool {
+
+    private final Plugin plugin;
+
+    public BarkbinderAxe(Plugin plugin) {
+        this.plugin = plugin;
+    }
 
     private static final Map<Material, Material> STRIPPED_TO_UNSTRIPPED = new HashMap<>();
 
@@ -48,7 +58,6 @@ public class BarkbinderAxe extends CustomTool {
 
     @Override
     public void handleInteract(Player player, PlayerInteractEvent event) {
-
         // Only continue if a block was right-clicked.
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getClickedBlock() == null) {
             return;
@@ -56,16 +65,9 @@ public class BarkbinderAxe extends CustomTool {
 
         Block block = event.getClickedBlock();
 
-        // Simulate a block break event to check for permissions.
-        BlockBreakEvent fakeBreakEvent = new BlockBreakEvent(block, player);
-        Bukkit.getPluginManager().callEvent(fakeBreakEvent);
-        if (fakeBreakEvent.isCancelled()) {
-            // The player doesn't have permission to break this block, cancel interaction.
-            return;
-        }
-
         ItemStack item = player.getInventory().getItemInMainHand();
 
+        // Check if the block is a stripped wood block
         Material strippedMaterial = block.getType();
         if (!STRIPPED_TO_UNSTRIPPED.containsKey(strippedMaterial)) {
             return;


### PR DESCRIPTION
Use of custom items (saplings & tools) has been disabled in regions without adequate permissions (Towny: wilderness, own town or trusted town; WorldGuard: override or BUILD flag permission) 